### PR TITLE
update to make scripts aware of 0.4.5 CLI

### DIFF
--- a/packages/Bond-Network/package.json
+++ b/packages/Bond-Network/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Bond Reference Data Sharing Business Network",
   "scripts": {
-    "prepublish": "mkdirp ./dist && composer archive create -d . -a ./dist/bond-network.bna",
+    "prepublish": "mkdirp ./dist && composer archive create  --sourceType dir --sourceName . -a ./dist/bond-network.bna",
     "pretest": "npm run lint",
     "lint": "eslint .",
     "postlint": "npm run licchk",

--- a/packages/CarAuction-Network/package.json
+++ b/packages/CarAuction-Network/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "description": "Car Auction Business Network",
   "scripts": {
-    "prepublish": "mkdirp ./dist && composer archive create -d . -a ./dist/carauction-network.bna",
+    "prepublish": "mkdirp ./dist && composer archive create  --sourceType dir --sourceName . -a ./dist/carauction-network.bna",
     "pretest": "npm run lint",
     "lint": "eslint .",
     "postlint": "npm run licchk",

--- a/packages/DigitalProperty-Network/package.json
+++ b/packages/DigitalProperty-Network/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.22",
   "description": "Digital Property Network",
   "scripts": {
-    "prepublish": "mkdirp ./dist && composer  archive create -d . -a ./dist/digitalproperty-network.zip",
+    "prepublish": "mkdirp ./dist && composer  archive create  --sourceType dir --sourceName . -a ./dist/digitalproperty-network.zip",
     "pretest": "npm run lint",
     "lint": "eslint .",
     "postlint": "npm run licchk",

--- a/packages/Marbles-Network/package.json
+++ b/packages/Marbles-Network/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Marble Trading Network",
   "scripts": {
-    "prepublish": "mkdirp ./dist && composer archive create -d . -a ./dist/marbles-network.bna",
+    "prepublish": "mkdirp ./dist && composer archive create --sourceType dir --sourceName . -a ./dist/marbles-network.bna",
     "pretest": "npm run lint",
     "lint": "eslint .",
     "postlint": "npm run licchk",

--- a/packages/Sample-Network/package.json
+++ b/packages/Sample-Network/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Sample Business Network",
   "scripts": {
-    "prepublish": "mkdirp ./dist && composer archive create -d . -a ./dist/sample-network.bna",
+    "prepublish": "mkdirp ./dist && composer archive create --sourceType dir --sourceName . -a ./dist/sample-network.bna",
     "pretest": "npm run lint",
     "lint": "eslint .",
     "postlint": "npm run licchk",


### PR DESCRIPTION
The create archive command is now

```
composer archive create --archiveFile digitialPropertyNetwork.zip --sourceType module --sourceName digitalproperty-network

Options:
  --help             Show help  [boolean]
  -v, --version      Show version number  [boolean]
  --archiveFile, -a  Business network archive file name. Default is based on the Identifier of the BusinessNetwork  [string]
  --sourceType, -t   The type of the input containg the files used to create the archive [ module | dir ]  [required]
  --sourceName, -n   The Location to create the archive from e.g. NPM module directory or Name of the npm module to use  [required]

```